### PR TITLE
Correct json syntax for module settings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,30 +52,30 @@ settings = {
 The valid engines are `adobe` or `lucee`.  By default the engine is `lucee`.  All module settings can be changed via the `boxlang.json` in your configuration.
 
 ```json
-"modules" : {
-    "compat-cfml" : {
-        "disabled" : false,
-        "settings" : {
-            "engine" : "adobe",
-			// JSON control character auto-escaping flag
-			// IF you turn to true, be aware that the entire JSON serialization will be escaped and be slower.
-			jsonEscapeControlCharacters = true,
-			// This simulates the query to empty value that Adobe/Lucee do when NOT in full null support
-			// We default it to true to simulate Adobe/Lucee behavior
-			queryNullToEmpty = true,
-			// The CF -> BL AST transpiler settings
-			// The transpiler is in the core, but will eventually live in this module, so the settings are here.
-            transpiler = {
-				// Turn foo.bar into foo.BAR
-				upperCaseKeys = true,
-				// Add output=true to functions and classes
-				forceOutputTrue = true,
-				// Merged doc comments into actual function, class, and property annotations
-				mergeDocsIntoAnnotations = true
-            }
-        }
-    }
-}
+"modules": {
+		"compat-cfml" : {
+			"disabled" : false,
+			"settings" : {
+				"engine" : "adobe",
+				// JSON control character auto-escaping flag
+				// IF you turn to true, be aware that the entire JSON serialization will be escaped and be slower.
+				"jsonEscapeControlCharacters" : true,
+				// This simulates the query to empty value that Adobe/Lucee do when NOT in full null support
+				// We default it to true to simulate Adobe/Lucee behavior
+				"queryNullToEmpty" : true,
+				// The CF -> BL AST transpiler settings
+				// The transpiler is in the core, but will eventually live in this module, so the settings are here.
+				"transpiler" : {
+					// Turn foo.bar into foo.BAR
+					"upperCaseKeys" : true,
+					// Add output=true to functions and classes
+					"forceOutputTrue" : true,
+					// Merged doc comments into actual function, class, and property annotations
+					"mergeDocsIntoAnnotations" : true
+				}
+			}
+		}
+	}
 ```
 
 ## Server Scope Mimic


### PR DESCRIPTION
Using the provided example was getting a compile error on startup of bx when using this module.

The json offered here (such as to be put in boxlang.json) is not syntactically correct, in that it uses `name = val` for most settings, when instead it should be `"name" : val`. 

It looks like someone copied it from the settings code offered at the TOP of the page...but that's for use in ModuleConfig.bx, wihch is code rather than json...but they'd corrected only the "engine" setting and left the others unchanged, thus this error.

## Type of change

Please delete options that are not relevant.

- [ ] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x] This change requires a documentation update
