### PR TITLE
WIP: Spec out datasource config listener for BL-1127.

### DIFF
--- a/src/main/java/ortus/boxlang/modules/compat/interceptors/RuntimeConfigListener.java
+++ b/src/main/java/ortus/boxlang/modules/compat/interceptors/RuntimeConfigListener.java
@@ -1,0 +1,38 @@
+package ortus.boxlang.modules.compat.interceptors;
+
+import ortus.boxlang.runtime.events.BaseInterceptor;
+import ortus.boxlang.runtime.events.InterceptionPoint;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.IStruct;
+
+/**
+ * This interceptor is used to convert null values to empty strings in query results
+ * for CFML compatibility.
+ *
+ * @author Ortus Solutions, Corp.
+ *
+ * @since 1.28.0
+ */
+public class RuntimeConfigListener extends BaseInterceptor {
+
+	/**
+	 * Listen for onDatasourceConfigLoad and decrypt any encrypted datasource passwords.
+	 *
+	 * Incoming data:
+	 * - name : The datasource name
+	 * - datasource : Datasource configuration struct
+	 *
+	 * @param interceptData
+	 */
+	@InterceptionPoint
+	public void onDatasourceConfigLoad( IStruct interceptData ) {
+		String	datasourceName		= interceptData.getAsString( Key._name );
+		IStruct	datasourceConfig	= interceptData.getAsStruct( Key.datasource );
+
+		decryptDatasourcePasswords( datasourceConfig );
+	}
+
+	private void decryptDatasourcePasswords( IStruct datasourceConfig ) {
+		// Implement your decryption logic here
+	}
+}

--- a/src/test/java/ortus/boxlang/modules/compat/interceptors/RuntimeConfigListenerTest.java
+++ b/src/test/java/ortus/boxlang/modules/compat/interceptors/RuntimeConfigListenerTest.java
@@ -1,0 +1,42 @@
+package ortus.boxlang.modules.compat.interceptors;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.modules.compat.BaseIntegrationTest;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.runtime.types.Struct;
+import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.util.FileSystemUtil;
+
+public class RuntimeConfigListenerTest extends BaseIntegrationTest {
+
+	@DisplayName( "It tests the datasource password decryption" )
+	@Test
+	public void testDatasourcePasswordDecryption() {
+		IStruct eventData = Struct.of(
+		    Key._name, "testDatasource",
+		    Key.datasource, Struct.of(
+		        Key.username, "testUser",
+		        Key.password, "isnotencrypted"
+		    )
+		);
+		runtime.announce( "onDatasourceConfigLoad", eventData );
+
+		assertThat( eventData.getAsStruct( Key.datasource ).getAsString( Key.password ) ).isEqualTo( "isnotencrypted" );
+
+		eventData = Struct.of(
+		    Key._name, "testDatasource2",
+		    Key.datasource, Struct.of(
+		        Key.username, "testUser",
+		        Key.password, "encrypted:xxx"
+		    )
+		);
+		runtime.announce( "onDatasourceConfigLoad", eventData );
+		assertThat( eventData.getAsStruct( Key.datasource ).getAsString( Key.password ) ).isEqualTo( "isDecrypted!" );
+	}
+
+}


### PR DESCRIPTION
# Description

Add support for lucee's encrypted password format in datasource configuration structs.

## Jira/Github Issues

https://ortussolutions.atlassian.net/browse/BL-1127

## Type of change

- [X] New Feature

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
