### PR TITLE
BL-2374 - Treat zero-duration cache timeouts as negative, set cache=false

### DIFF
--- a/src/main/bx/interceptors/QueryCompat.bx
+++ b/src/main/bx/interceptors/QueryCompat.bx
@@ -109,6 +109,12 @@ class{
 				modifiedOptions.cache = structOptions.cache ?: true;
 			}
 		}
+		var zeroTimespan = createTimeSpan( 0, 0, 0, 0 );
+		if( structOptions.keyExists( "cacheTimeout" ) && !isNull( structOptions.cacheTimeout ) && zeroTimespan.equals( structOptions.cacheTimeout ) ){
+			// Treat 0 cacheTimeout as cache=false.
+			modifiedOptions.cacheTimeout = createTimeSpan( -1, 0, 0, 0 );
+			modifiedOptions.cache = false;
+		}
 
 		// Construct a new QueryOptions instance from the modified options struct
 		if( !modifiedOptions.isEmpty() ){

--- a/src/test/java/ortus/boxlang/modules/compat/interceptors/QueryCompatTest.java
+++ b/src/test/java/ortus/boxlang/modules/compat/interceptors/QueryCompatTest.java
@@ -1,0 +1,31 @@
+package ortus.boxlang.modules.compat.interceptors;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.modules.compat.BaseIntegrationTest;
+
+public class QueryCompatTest extends BaseIntegrationTest {
+
+	@DisplayName( "It converts zero timeouts to negative timeouts" )
+	@Test
+	public void testZeroCacheTimeout() {
+		// @formatter:off
+		runtime.executeSource(
+		    """
+				import java:ortus.boxlang.runtime.jdbc.QueryOptions;
+				import src.main.bx.interceptors.QueryCompat;
+				options = new QueryOptions({
+					cache       : true,
+					cacheTimeout: createTimeSpan( 0, 0, 0, 0 )
+				});
+
+				interceptData = { bindings : [], options : options };
+				new QueryCompat().onQueryBuild( interceptData );
+				assert interceptData.options.cache == false;
+				assert interceptData.options.cacheTimeout < 0;
+			   """,
+		    context );
+		// @formatter:on
+	}
+}


### PR DESCRIPTION
# Description

Treat zero-duration cache timeouts as negative, set `cache=false`.

## Jira/Github Issues

https://ortussolutions.atlassian.net/browse/BL-2374

## Type of change

- [x] Bug Fix
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
