### PR TITLE
v1.34.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.33.0] - 2026-05-21
+
 ### Added
 
 - [BLMODULES-207](https://ortussolutions.atlassian.net/browse/BLMODULES-207) - add qry.getColumnList() -> array for CF compat
@@ -18,8 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [BLMODULES-210](https://ortussolutions.atlassian.net/browse/BLMODULES-210) - Fix QueryCompat failing in ASMBoxpiler with `cannot use a function parameter with the same name as an import`
 - [BLMODULES-187](https://ortussolutions.atlassian.net/browse/BLMODULES-187) - Set spreadsheet module to default type of binary
 - [BL-2389](https://ortussolutions.atlassian.net/browse/BL-2389) - For ACF compat, treat empty strings as list with one value in listQualify()
-- [BL-2435](https://ortussolutions.atlassian.net/browse/BL-2435) - For ACF compat, accept dates in array max/min/sum BIFs
-- [BL-2374](https://ortussolutions.atlassian.net/browse/BL-2374) - Treat zero-length `cacheTimeout` as negative timeout to evict cache entry. 
+- [BL-2374](https://ortussolutions.atlassian.net/browse/BL-2374) - Treat zero-length `cacheTimeout` as negative timeout to evict cache entry.
 
 ### Changed
 
@@ -241,7 +242,8 @@ transpiler = {
 
 - First iteration of this module
 
-[unreleased]: https://github.com/ortus-boxlang/bx-compat-cfml/compare/v1.32.1...HEAD
+[unreleased]: https://github.com/ortus-boxlang/bx-compat-cfml/compare/v1.33.0...HEAD
+[1.33.0]: https://github.com/ortus-boxlang/bx-compat-cfml/compare/v1.32.1...v1.33.0
 [1.32.1]: https://github.com/ortus-boxlang/bx-compat-cfml/compare/v1.32.0...v1.32.1
 [1.32.0]: https://github.com/ortus-boxlang/bx-compat-cfml/compare/v1.31.0...v1.32.0
 [1.31.0]: https://github.com/ortus-boxlang/bx-compat-cfml/compare/v1.30.2...v1.31.0

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [BL-2435](https://ortussolutions.atlassian.net/browse/BL-2435) - For ACF compat, accept dates in array max/min/sum BIFs
+- Override `enableNestedTransactions` setting to `false` for compat mode in boxlang@1.13.0 and below. (previously only 1.12).
 
 ## [1.33.0] - 2026-05-21
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [BL-2435](https://ortussolutions.atlassian.net/browse/BL-2435) - For ACF compat, accept dates in array max/min/sum BIFs
+
 ## [1.33.0] - 2026-05-21
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Tue Apr 21 16:41:28 UTC 2026
+#Thu May 21 15:28:52 UTC 2026
 boxlangVersion=1.14.0
 jdkVersion=21
-version=1.33.0
+version=1.34.0
 group=ortus.boxlang

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #Tue Apr 21 16:41:28 UTC 2026
-boxlangVersion=1.13.0
+boxlangVersion=1.14.0
 jdkVersion=21
 version=1.34.0
 group=ortus.boxlang

--- a/src/main/bx/ModuleConfig.bx
+++ b/src/main/bx/ModuleConfig.bx
@@ -300,11 +300,12 @@ import ortus.boxlang.runtime.types.Query;
 
 		runtimeConfig = boxRuntime.getConfiguration();
 		// Revert to ACF and Lucee-compatible JDBC nested transacton behavior if the setting is not explicitly set by the user.
-		if( val( GetBoxVersionInfo().version ) == 1.12 ){
-			// In older versions of BoxLang, this setting defaulted to true with no way to detect user config.
+		if( val( GetBoxVersionInfo().version ) <= 1.13 ){
+			// In BL 1.12-1.13, this setting defaulted to true with no way to detect user config.
 			runtimeConfig.enableNestedTransactions = false;
+			getBoxContext().clearConfigCache();
 		} else if( structKeyExists( runtimeConfig, "enableNestedTransactions" ) && isNull( runtimeConfig.enableNestedTransactions ) ){
-			// For 1.13.0+ we only override if the setting is null to avoid clobbering user settings.  This allows users to opt into the new nested transaction behavior if they want while maintaining backwards compatibility by default.
+			// For 1.14.0+ we only override if the setting is null to avoid clobbering user settings.  This allows users to opt into the new nested transaction behavior if they want while maintaining backwards compatibility by default.
 			runtimeConfig.enableNestedTransactions = false;
 			// Clear our config cache
 			getBoxContext().clearConfigCache();

--- a/src/main/bx/interceptors/QueryCompat.bx
+++ b/src/main/bx/interceptors/QueryCompat.bx
@@ -16,8 +16,6 @@
  * limitations under the License.
  */
 
-import java:ortus.boxlang.runtime.types.unmodifiable.UnmodifiableStruct;
-import java:ortus.boxlang.runtime.scopes.Key;
 import java:ortus.boxlang.runtime.jdbc.QueryOptions;
 
 /**

--- a/src/test/java/ortus/boxlang/modules/compat/bifs/temporal/DateTimeFormatTest.java
+++ b/src/test/java/ortus/boxlang/modules/compat/bifs/temporal/DateTimeFormatTest.java
@@ -343,4 +343,16 @@ public class DateTimeFormatTest extends BaseIntegrationTest {
 		assertEquals( "09:05:03", variables.getAsString( Key.of( "result" ) ) );
 	}
 
+	@DisplayName( "date format gives the same original date from a number" )
+	@Test
+	public void testDateFormatGivesSameOriginalDateFromNumber() {
+		runtime.executeSource(
+		    """
+		       result1 = dateFormat( now(), "mm/dd/yyyy" );
+		    result2 = dateFormat( [ now() ].max(), "mm/dd/yyyy" );
+		       """,
+		    context );
+		assertEquals( variables.getAsString( Key.of( "result1" ) ), variables.getAsString( Key.of( "result2" ) ) );
+	}
+
 }


### PR DESCRIPTION
# v1.34.0

### Fixed

- [BL-2435](https://ortussolutions.atlassian.net/browse/BL-2435) - For ACF compat, accept dates in array max/min/sum BIFs
- Override `enableNestedTransactions` setting to `false` for compat mode in boxlang@1.13.0 and below. (previously only 1.12).

[BL-2435]: https://ortussolutions.atlassian.net/browse/BL-2435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ